### PR TITLE
Avoid zombie processes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Avoid zombie processes. [jone]
+
 - Add zcml:condition for Plone 3 compatibility
   [gborelli]
 


### PR DESCRIPTION
Since the warmup subprocess waits for Zope to be finished starting up and handling requests, we should not block the startup.
But it is important to collect the result of the subprocess (by using `subprocess.check_call`) in order to avoid zombie processes.
However, since `subprocess.check_call` is blocking the caller, we call it within a new thread which will have the patience to wait for the subprocess to finish and the main startup process can continue.

See [this stackoverflow question](http://stackoverflow.com/questions/16807603/python-non-blocking-non-defunct-process) for more info about zombie processes.
